### PR TITLE
Configured modules and routing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7932,9 +7932,9 @@
       "dev": true
     },
     "ng2-charts": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/ng2-charts/-/ng2-charts-2.4.2.tgz",
-      "integrity": "sha512-mY3C2uKCaApHCQizS2YxEOqQ7sSZZLxdV6N1uM9u/VvUgVtYvlPtdcXbKpN52ak93ZE22I73DiLWVDnDNG4/AQ==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/ng2-charts/-/ng2-charts-2.4.3.tgz",
+      "integrity": "sha512-tPrhHSS2DfVyipXQ0gykOPc8zFNnj2b7sAebUVty392vHnEGYCwsP6YbFfpr1iXu4yBSRm4Gt5lffR5w0uyYSw==",
       "requires": {
         "@types/chart.js": "^2.9.24",
         "lodash-es": "^4.17.15",

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -1,10 +1,16 @@
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 
-const routes: Routes = [];
+const routes: Routes = [
+  {
+    path: '',
+    loadChildren: () =>
+      import('./chart/chart.module').then((mod) => mod.ChartModule),
+  },
+];
 
 @NgModule({
   imports: [RouterModule.forRoot(routes)],
-  exports: [RouterModule]
+  exports: [RouterModule],
 })
-export class AppRoutingModule { }
+export class AppRoutingModule {}

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,5 +1,6 @@
-<app-charts-home></app-charts-home>
-<app-charts-input></app-charts-input>
-<router-outlet></router-outlet>
-
-
+<div class="container mt-4">
+  <h1>Chart Demo App</h1>
+  <div class="mt-4">
+    <router-outlet></router-outlet>
+  </div>
+</div>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,12 +1,8 @@
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
-import { ChartsModule } from 'ng2-charts';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-
-import { ChartModule } from './chart/chart.module';
 
 @NgModule({
   declarations: [
@@ -14,10 +10,7 @@ import { ChartModule } from './chart/chart.module';
   ],
   imports: [
     BrowserModule,
-    AppRoutingModule,
-    BrowserAnimationsModule,
-    ChartsModule,
-    ChartModule
+    AppRoutingModule
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/src/app/chart/chart-routing.module.ts
+++ b/src/app/chart/chart-routing.module.ts
@@ -1,10 +1,17 @@
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 
-const routes: Routes = [];
+import { ChartComponent } from './chart.component';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: ChartComponent,
+  },
+];
 
 @NgModule({
   imports: [RouterModule.forChild(routes)],
-  exports: [RouterModule]
+  exports: [RouterModule],
 })
-export class ChartRoutingModule { }
+export class ChartRoutingModule {}

--- a/src/app/chart/chart.component.html
+++ b/src/app/chart/chart.component.html
@@ -1,0 +1,8 @@
+<div class="row">
+  <div class="col">
+    <app-charts-input></app-charts-input>
+  </div>
+  <div class="col">
+    <app-charts-home></app-charts-home>
+  </div>
+</div>

--- a/src/app/chart/chart.component.ts
+++ b/src/app/chart/chart.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-chart',
+  templateUrl: './chart.component.html',
+  styleUrls: ['./chart.component.css']
+})
+export class ChartComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/app/chart/chart.module.ts
+++ b/src/app/chart/chart.module.ts
@@ -1,21 +1,24 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule } from '@angular/forms';
+import { ChartsModule } from 'ng2-charts';
 
 import { ChartRoutingModule } from './chart-routing.module';
+import { ChartComponent } from './chart.component';
 import { ChartsHomeComponent } from './charts-home/charts-home.component';
 import { ChartsInputComponent } from './charts-input/charts-input.component';
-import { ChartsModule } from 'ng2-charts';
-import { ReactiveFormsModule } from '@angular/forms';
-
 
 @NgModule({
-  declarations: [ChartsHomeComponent, ChartsInputComponent],
+  declarations: [
+    ChartsHomeComponent, 
+    ChartsInputComponent, 
+    ChartComponent,
+  ],
   imports: [
     CommonModule,
     ChartRoutingModule,
     ChartsModule,
-    ReactiveFormsModule
+    ReactiveFormsModule,
   ],
-  exports: [ChartsHomeComponent, ChartsInputComponent]
 })
-export class ChartModule { }
+export class ChartModule {}

--- a/src/app/chart/charts-home/charts-home.component.html
+++ b/src/app/chart/charts-home/charts-home.component.html
@@ -1,4 +1,4 @@
-<div style="width: 40%;">
+<div>
   <canvas
     baseChart
     [chartType]="'line'"

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,1 +1,1 @@
-/* You can add global styles to this file, and also import other style files */
+@import "~bootstrap/dist/css/bootstrap.css";


### PR DESCRIPTION
A couple of changes here...

Firstly, imported bootsrap css into styles.

You have routing set up, so it makes sense to use it. 
In app-routing I created a single path which then imports the Chart module.
In chart-routing I created another path, straight to a component. This is a new component designed to contain your other chart components.

Cleaned up app.module. These chart components don't need to be imported here, they are declared in the charts module, and should be used exclusively within the charts module. For the same reason I removed the exports from chart.module.

app.component now can't use the chart components. So I trimmed it down to just the router outlet and popped it inside a bootstrap container.

Finally, the new chart.component is where the charts-input and charts-home components are placed.